### PR TITLE
OHRI-2201: Enable view of other forms on the Active Visits Widget

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -189,19 +189,24 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
           <TabPanel>
             <MedicationSummary medications={medications} />
           </TabPanel>
-          {visit?.encounters?.length > 0 && foundEncounter && (
-            <TabPanel key={selectedIndex}>
-              <ExtensionSlot
-                name="form-widget-slot"
-                state={{
-                  additionalProps: { mode: 'embedded-view' },
-                  formUuid: foundEncounter.form?.uuid,
-                  encounterUuid: foundEncounter.uuid,
-                  patientUuid: patientUuid,
-                }}
-              />
-            </TabPanel>
-          )}
+          {visit?.encounters?.length > 0 &&
+            visit?.encounters
+              .filter((enc) => !!enc.form)
+              .map((enc, ind) => (
+                <TabPanel key={ind}>
+                  {selectedTab === enc.uuid && (
+                    <ExtensionSlot
+                      name="form-widget-slot"
+                      state={{
+                        additionalProps: { mode: 'embedded-view' },
+                        formUuid: enc.form?.uuid,
+                        encounterUuid: enc.uuid,
+                        patientUuid: patientUuid,
+                      }}
+                    />
+                  )}
+                </TabPanel>
+              ))}
           <ExtensionSlot name={visitSummaryPanelSlot}>
             <TabPanel>
               <Extension state={{ patientUuid, visit }} />


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Enable view of other forms on the Active Visits Widget

## Screenshots
<!-- Required if you are making UI changes. -->
[Screencast from 23-04-2024 08:53:04 ASUBUHI.webm](https://github.com/UCSF-IGHS/openmrs-esm-patient-chart/assets/130601439/23601700-ca1f-46c8-836c-7b8b991a9d66)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
