### PR TITLE
fix: ensure we can  cancel/end/detete the enc $ return empty state

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/active-visit-buttons/active-visit-buttons.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/active-visit-buttons/active-visit-buttons.tsx
@@ -1,17 +1,15 @@
-import { launchPatientWorkspace, useLaunchWorkspaceRequiringVisit } from '@openmrs/esm-patient-common-lib';
 import React, { useCallback } from 'react';
 import styles from './active-visit-buttons.scss';
 import { useTranslation } from 'react-i18next';
 import { Button, MenuButton, MenuItem } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
+import { useLaunchWorkspaceRequiringVisit, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import type { Visit } from '@openmrs/esm-framework';
 import { showModal, useLayoutType, useConfig } from '@openmrs/esm-framework';
-
 interface ActiveVisitActionsInterface {
   visit: Visit;
   patientUuid: string;
 }
-
 interface ActiveVisitProps {
   encounterUuid: string;
   formUuid: string;
@@ -20,11 +18,11 @@ interface ActiveVisitProps {
 }
 
 const ActiveVisitActions: React.FC<ActiveVisitActionsInterface & ActiveVisitProps> = ({
-                                                                                        patientUuid,
-                                                                                        mutateform,
-                                                                                        action,
-                                                                                        visit,
-                                                                                      }) => {
+  patientUuid,
+  mutateform,
+  action,
+  visit,
+}) => {
   const config = useConfig();
   const { t } = useTranslation();
   const layout = useLayoutType();
@@ -53,48 +51,55 @@ const ActiveVisitActions: React.FC<ActiveVisitActionsInterface & ActiveVisitProp
     });
   };
 
+  const launchAllergiesFormWorkspace = useLaunchWorkspaceRequiringVisit('patient-allergy-form-workspace');
+  const launchAppointmentsFormWorkspace = useLaunchWorkspaceRequiringVisit('appointments-form-workspace');
+  const launchClinicalFormsWorkspace = useLaunchWorkspaceRequiringVisit('clinical-forms-workspace');
+  const launchConditionsFormWorkspace = useLaunchWorkspaceRequiringVisit('conditions-form-workspace');
+  const launchOrderBasketFormWorkspace = useLaunchWorkspaceRequiringVisit('order-basket');
+  const launchVitalsAndBiometricsFormWorkspace = useLaunchWorkspaceRequiringVisit(
+    'patient-vitals-biometrics-form-workspace',
+  );
   return (
     <div>
       {isTablet || isMobile ? (
         <div className={styles.buttonsContainer}>
           <VisitActionsComponent patientUuid={patientUuid} visit={visit} />
-
           <MenuButton label={t('more', 'More')} kind="ghost">
             <MenuItem kind="ghost" label={t('addNote', 'Add note')} onClick={handleLaunchNotesForm} renderIcon={Add} />
             <MenuItem
               kind="ghost"
               label={t('addLabOrPrescription', 'Add lab or prescription')}
-              onClick={useLaunchWorkspaceRequiringVisit('order-basket')}
+              onClick={launchOrderBasketFormWorkspace}
               renderIcon={Add}
             />
             <MenuItem
               kind="ghost"
               label={t('addVitals', 'Add vitals')}
-              onClick={useLaunchWorkspaceRequiringVisit('patient-vitals-biometrics-form-workspace')}
+              onClick={launchVitalsAndBiometricsFormWorkspace}
               renderIcon={Add}
             />
             <MenuItem
               kind="ghost"
               label={t('addCondition', 'Add condition')}
-              onClick={useLaunchWorkspaceRequiringVisit('conditions-form-workspace')}
+              onClick={launchConditionsFormWorkspace}
               renderIcon={Add}
             />
             <MenuItem
               kind="ghost"
               label={t('addAllergy', 'Add allergy')}
-              onClick={useLaunchWorkspaceRequiringVisit('patient-allergy-form-workspace')}
+              onClick={launchAllergiesFormWorkspace}
               renderIcon={Add}
             />
             <MenuItem
               kind="ghost"
               label={t('addAppointment', 'Add appointment')}
-              onClick={useLaunchWorkspaceRequiringVisit('appointments-form-workspace')}
+              onClick={launchAppointmentsFormWorkspace}
               renderIcon={Add}
             />
             <MenuItem
               kind="ghost"
               label={t('otherForm', 'Other form')}
-              onClick={useLaunchWorkspaceRequiringVisit('clinical-forms-workspace')}
+              onClick={launchClinicalFormsWorkspace}
               renderIcon={Add}
             />
           </MenuButton>
@@ -113,42 +118,40 @@ const ActiveVisitActions: React.FC<ActiveVisitActionsInterface & ActiveVisitProp
             kind="ghost"
             renderIcon={(props) => <Add size={16} {...props} />}
             iconDescription="Add lab or prescription"
-            onClick={useLaunchWorkspaceRequiringVisit('order-basket')}
+            onClick={launchOrderBasketFormWorkspace}
           >
             {t('addLabOrPrescription', 'Add lab or prescription')}
           </Button>
-
           <VisitActionsComponent patientUuid={patientUuid} visit={visit} />
-
           <MenuButton label={t('more', 'More')} kind="ghost">
             <MenuItem
               kind="ghost"
               label={t('addVitals', 'Add vitals')}
-              onClick={useLaunchWorkspaceRequiringVisit('patient-vitals-biometrics-form-workspace')}
+              onClick={launchVitalsAndBiometricsFormWorkspace}
               renderIcon={Add}
             />
             <MenuItem
               kind="ghost"
               label={t('addCondition', 'Add condition')}
-              onClick={useLaunchWorkspaceRequiringVisit('conditions-form-workspace')}
+              onClick={launchConditionsFormWorkspace}
               renderIcon={Add}
             />
             <MenuItem
               kind="ghost"
               label={t('addAllergy', 'Add allergy')}
-              onClick={useLaunchWorkspaceRequiringVisit('patient-allergy-form-workspace')}
+              onClick={launchAllergiesFormWorkspace}
               renderIcon={Add}
             />
             <MenuItem
               kind="ghost"
               label={t('addAppointment', 'Add appointment')}
-              onClick={useLaunchWorkspaceRequiringVisit('appointments-form-workspace')}
+              onClick={launchAppointmentsFormWorkspace}
               renderIcon={Add}
             />
             <MenuItem
               kind="ghost"
               label={t('otherForm', 'Other form')}
-              onClick={useLaunchWorkspaceRequiringVisit('clinical-forms-workspace')}
+              onClick={launchClinicalFormsWorkspace}
               renderIcon={Add}
             />
           </MenuButton>
@@ -157,7 +160,6 @@ const ActiveVisitActions: React.FC<ActiveVisitActionsInterface & ActiveVisitProp
     </div>
   );
 };
-
 export default ActiveVisitActions;
 interface VisitActionsProps {
   patientUuid: string;

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -96,6 +96,8 @@
   "name": "Name",
   "no": "No",
   "noActiveVisit": "No Active Visit",
+  "noActiveVisits": "No active visits",  
+  "noActiveVisitsAvailable": "Visits",
   "noActiveVisitMessage": "active visit",
   "noActiveVisitNoRDEText": "You can't add data to the patient chart without an active visit. Would you like to start a new visit?",
   "noActiveVisitText": "You can't add data to the patient chart without an active visit. Choose from one of the options below to continue.",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This pr address the following:

Cancel/end/detete the enc
Return empty state for patients with no active visists
Navigate to the active-visits page after starting new visit

## Screenshots
<!-- Required if you are making UI changes. -->
[Screencast from 09-05-2024 04:19:06 ALASIRI.webm](https://github.com/UCSF-IGHS/openmrs-esm-patient-chart/assets/130601439/2941671b-a3bd-4ca2-bea7-e8b58da9780a)

![image](https://github.com/UCSF-IGHS/openmrs-esm-patient-chart/assets/130601439/ba0ad404-d1ff-4cd6-8384-56ce9d49d053)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
